### PR TITLE
php7.4 phpビルド時にgdでこける

### DIFF
--- a/apache/docker/php/Dockerfile
+++ b/apache/docker/php/Dockerfile
@@ -20,8 +20,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure \
         gd \
         --enable-gd-native-ttf \
-        --with-freetype-dir=/usr/include/freetype2 \
-        --with-png-dir=/usr/include \
-        --with-jpeg-dir=/usr/include \
+        --with-freetype \
+        --with-jpeg \
     && docker-php-ext-install gd pdo_mysql mysqli \
     && a2enmod rewrite

--- a/cms/concrete5-apache/docker/php/Dockerfile
+++ b/cms/concrete5-apache/docker/php/Dockerfile
@@ -15,9 +15,8 @@ RUN apt-get update && apt-get install -y \
         unzip \
     && docker-php-ext-configure \
         gd \
-        --with-freetype-dir=/usr/include/ \
-        --with-jpeg-dir=/usr/include/ \
-        --with-png-dir=/usr/include/ \
+        --with-freetype \
+        --with-jpeg \
     && docker-php-ext-install \
         gd \
         pdo_mysql \

--- a/cms/wordpress-apache/docker/php/Dockerfile
+++ b/cms/wordpress-apache/docker/php/Dockerfile
@@ -15,9 +15,8 @@ RUN apt-get update && apt-get install -y \
         unzip \
     && docker-php-ext-configure \
         gd \
-        --with-freetype-dir=/usr/include/ \
-        --with-jpeg-dir=/usr/include/ \
-        --with-png-dir=/usr/include/ \
+        --with-freetype \
+        --with-jpeg \
     && docker-php-ext-install \
         gd \
         pdo_mysql \

--- a/nginx/docker/php/Dockerfile
+++ b/nginx/docker/php/Dockerfile
@@ -1,7 +1,5 @@
-FROM php:7.4-fpm
-
-COPY php.ini /usr/local/etc/php/
-
+FROM php:7.4-apache
+COPY ./php.ini /usr/local/etc/php/
 
 RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
@@ -13,8 +11,21 @@ RUN apt-get update && apt-get install -y \
         libzip-dev \
         libonig-dev \
         graphviz \
+        unzip \
+    && docker-php-ext-configure \
+        gd \
+        --with-freetype \
+        --with-jpeg \
     && docker-php-ext-install \
         gd \
         pdo_mysql \
         mysqli \
         zip \
+    && a2enmod rewrite
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_HOME /composer
+ENV PATH $PATH:/composer/vendor/bin
+
+RUN composer global require "laravel/installer"


### PR DESCRIPTION
ビルド時にgdでこけるので修正

```
&& docker-php-ext-configure \
        gd \
        --with-freetype-dir=/usr/include/ \
        --with-jpeg-dir=/usr/include/ \
        --with-png-dir=/usr/include/ \
```
ではなく、
```
&& docker-php-ext-configure \
        gd \
        --with-freetype \
        --with-jpeg \
```
の記述の仕方で良い